### PR TITLE
Fix typo and HTML in resume page

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Sam Peldey - Resume
+title: Sam Pedley - Resume
 permalink: /resume/
 description: My name is Sam and I love LAMP.
 image: /public/img/booger.jpg
@@ -19,4 +19,3 @@ theme: resume
 
   <button class="print_hide resume_print" onclick="window.print()">Print or Save as PDF</button>
   
-</section>


### PR DESCRIPTION
## Summary
- correct typo in resume page title
- remove stray closing `</section>` tag

## Testing
- `bundle exec jekyll build --verbose` *(fails: bundler not installed for ruby 3.2)*

------
https://chatgpt.com/codex/tasks/task_e_6877ccf3658483229bc2d40ba6472de5